### PR TITLE
Makefile: build with clang on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CXXFLAGS=-std=c++11 -Wall -pedantic -Wfatal-errors -g -I./include
 CXXOPTIMIZATIONFLAGS=
+COPTIMIZATIONFLAGS=
 
 VIUA_CPU_INSTR_FILES_CPP=src/cpu/instr/general.cpp src/cpu/instr/registers.cpp src/cpu/instr/calls.cpp src/cpu/instr/linking.cpp src/cpu/instr/tcmechanism.cpp src/cpu/instr/closure.cpp src/cpu/instr/int.cpp src/cpu/instr/float.cpp src/cpu/instr/byte.cpp src/cpu/instr/str.cpp src/cpu/instr/bool.cpp src/cpu/instr/cast.cpp src/cpu/instr/vector.cpp
 VIUA_CPU_INSTR_FILES_O=build/cpu/instr/general.o build/cpu/instr/registers.o build/cpu/instr/calls.o build/cpu/instr/linking.o build/cpu/instr/tcmechanism.o build/cpu/instr/closure.o build/cpu/instr/int.o build/cpu/instr/float.o build/cpu/instr/byte.o build/cpu/instr/str.o build/cpu/instr/bool.o build/cpu/instr/cast.o build/cpu/instr/vector.o
@@ -9,6 +10,7 @@ BIN_PATH=${PREFIX}/bin
 LIB_PATH=${PREFIX}/lib/viua
 H_PATH=/usr/include/viua
 
+LIBDL=-ldl
 
 .SUFFIXES: .cpp .h .o
 
@@ -91,10 +93,10 @@ version:
 
 
 build/bin/vm/cpu: src/front/cpu.cpp build/cpu/cpu.o build/cpu/dispatch.o build/cpu/registserset.o build/loader.o build/printutils.o build/support/pointer.o build/support/string.o ${VIUA_CPU_INSTR_FILES_O} build/types/vector.o build/types/function.o build/types/closure.o build/types/string.o build/types/exception.o
-	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -o $@ $^ -ldl
+	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -o $@ $^ $(LIBDL)
 
 build/bin/vm/vdb: src/front/wdb.cpp build/lib/linenoise.o build/cpu/cpu.o build/cpu/dispatch.o build/cpu/registserset.o build/loader.o build/cg/disassembler/disassembler.o build/printutils.o build/support/pointer.o build/support/string.o ${VIUA_CPU_INSTR_FILES_O} build/types/vector.o build/types/function.o build/types/closure.o build/types/string.o build/types/exception.o
-	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -o $@ $^ -ldl
+	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -o $@ $^ $(LIBDL)
 
 build/bin/vm/asm: src/front/asm.cpp build/program.o build/programinstructions.o build/cg/assembler/operands.o build/cg/assembler/ce.o build/cg/assembler/verify.o build/cg/bytecode/instructions.o build/loader.o build/support/string.o
 	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -o $@ $^
@@ -225,4 +227,4 @@ build/support/pointer.o: src/support/pointer.cpp
 
 
 build/lib/linenoise.o: lib/linenoise/linenoise.c lib/linenoise/linenoise.h
-	${CXX} ${CXXFLAGS} ${CXXOPTIMIZATIONFLAGS} -c -o $@ $<
+	${CC} ${CFLAGS} ${COPTIMIZATIONFLAGS} -c -o $@ $<


### PR DESCRIPTION
- Not all systems have or need -ldl (added LIBDL for now)

- libnoise is better to be compiled with a C compiler, otherwise clang++ complains:

lib/linenoise/linenoise.c:539:27: warning: must specify at least one
      argument for '...' parameter of variadic macro
      [-Wgnu-zero-variadic-macro-arguments]
        lndebug("clear+up");
                          ^
lib/linenoise/linenoise.c:197:9: note: macro 'lndebug' defined here
        ^