### PR TITLE
Add two tests:

### DIFF
--- a/sample/asm/exceptions/restore_catcher_state.asm
+++ b/sample/asm/exceptions/restore_catcher_state.asm
@@ -1,0 +1,55 @@
+.block: handle_integer
+    ; pull caught object into 2 register
+    pull 2
+    print 2
+    print 4
+    leave
+.end
+
+.function: tertiary
+    arg 3 0
+    istore 4 300
+    throw 3
+    end
+.end
+
+.function: secondary
+    arg 2 0
+    istore 4 200
+    frame 1 5
+    istore 4 250
+    param 0 2
+    call tertiary
+    istore 4 225
+    end
+.end
+
+.block: main_block
+    istore 1 42
+    istore 4 100
+    frame 1 5
+    param 0 1
+    call secondary
+    istore 2 41
+    istore 4 125
+    leave
+.end
+
+
+.function: main
+    istore 4 50
+    tryframe
+    catch "Integer" handle_integer
+    try main_block
+    ; leave instructions lead here
+    print 2
+    print 4
+    izero 0
+    end
+.end
+
+
+; catch "<type>" <block>    - registers a catcher <block> for given <type>
+; try <block>               - tries executing given block after registered catchers have been registered
+; leave                     - leaves active block (if any) and resumes execution on instruction after the one that caused
+;                             the block to be entered

--- a/sample/asm/functions/neverending.asm
+++ b/sample/asm/functions/neverending.asm
@@ -1,0 +1,20 @@
+.function: one
+    istore 1 42
+    print 1
+    izero 0
+    ; no end here
+.end
+
+.function: two
+    istore 1 48
+    print 1
+    izero 0
+    end
+.end
+
+.function: main
+    frame 0 2
+    call one
+    izero 0
+    end
+.end

--- a/sample/asm/functions/neverending0.asm
+++ b/sample/asm/functions/neverending0.asm
@@ -1,0 +1,13 @@
+.function: one
+    istore 1 42
+    print 1
+    izero 0
+    ; no end here
+.end
+
+.function: main
+    frame 0 2
+    call one
+    izero 0
+    end
+.end

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -420,6 +420,13 @@ class FunctionTests(unittest.TestCase):
     def testStaticRegisters(self):
         runTestReturnsIntegers(self, 'static_registers.asm', [i for i in range(0, 10)])
 
+    def testNeverendingFunction(self):
+        runTestSplitlines(self, 'neverending.asm', ['42', '48'])
+
+    @unittest.skip('this test hangs the VM until it runs out of memory')
+    def testNeverendingFunction0(self):
+        runTest(self, 'neverending0.asm', '42')
+
 
 class HigherOrderFunctionTests(unittest.TestCase):
     """Tests for higher-order function support.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -531,6 +531,9 @@ class CatchingMachineThrownExceptionTests(unittest.TestCase):
     def testCatchingMachineThrownException(self):
         runTest(self, 'nullregister_access.asm', "exception encountered: (get) read from null register: 1")
 
+    def testCatcherState(self):
+        runTestSplitlines(self, 'restore_catcher_state.asm', ['42','100','42','100'])
+
 
 class AssemblerErrorTests(unittest.TestCase):
     """Tests for error-checking and reporting functionality.


### PR DESCRIPTION
- stack unwinding

- missing "end" in a function (fallthrough behaviour currently)